### PR TITLE
fixed namespaces not getting session information

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ module.exports.init = function (options) {
   /**
 	 * Add a new socket.io route (convenience method)
 	 * @param  {String}   [namespace] socket.io namespace. Defaults to "/".
-	 * @param  {String}   route     the route name (should be unique)
+	 * @param  {String}   eventName     the event name (should be unique)
 	 * @param  {Function} fn        function(socket, data) { ... }
 	 */
   _app.io.route = function (namespace, eventName, fn) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,13 +79,3 @@ module.exports.init = function (options) {
   return _app;
 
 };
-
-/** PRIVATE **/
-
-function setInvalidSession(socket) {
-  socket.session = {};
-  socket.session.save = function (callback) {
-    callback = callback || function () { };
-    callback("Session if not initialized. Init it with a classic express request.");
-  }
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,10 +72,20 @@ module.exports.init = function (options) {
 	 * @param  {String}   route     the route name (should be unique)
 	 * @param  {Function} fn        function(socket, data) { ... }
 	 */
-  _app.io.route = function (namespace, route, fn) {
-    _router.add(namespace, route, fn);
+  _app.io.route = function (namespace, eventName, fn) {
+    _router.add(namespace, eventName, fn);
   }
 
   return _app;
 
+};
+
+/** PRIVATE **/
+
+function setInvalidSession(socket) {
+  socket.session = {};
+  socket.session.save = function (callback) {
+    callback = callback || function () { };
+    callback("Session if not initialized. Init it with a classic express request.");
+  }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,120 +12,80 @@ var express = require('express'),
 	io = require('socket.io'),
 	Router = require("./router.js");
 
-module.exports.init = function(options) {
+module.exports.init = function (options) {
 
-	var _app, _server;
+  var _app, _server;
 
-	//Init IO Router
-	var _router = new Router();
+  if (!options) options = {};
 
-	if (!options) options = {};
-
-	//Defaults values for options
-	options.name = options.name || 'sockpress.id';
-	options.store = options.store || new session.MemoryStore();
-	options.resave = options.resave === undefined
+  //Defaults values for options
+  options.name = options.name || 'sockpress.id';
+  options.store = options.store || new session.MemoryStore();
+  options.resave = options.resave === undefined
 		? true
 		: false
-	options.saveUninitialized = options.saveUninitialized === undefined
+  options.saveUninitialized = options.saveUninitialized === undefined
 		? true
 		: false
 
-	_app = express(); //load an express instance
-	_app.express = express; //expose raw express object for middlewares
+  _app = express(); //load an express instance
+  _app.express = express; //expose raw express object for middlewares
 
-	if(!options.https) //load http or https nodejs server
-		_server = require('http').createServer(_app);
-	else
-		_server = require('https').createServer(options.https, _app);
-	
-	if(!options.disableSession)
-		_app.use(session(options)); //enable session support in express
+  if (!options.https) //load http or https nodejs server
+    _server = require('http').createServer(_app);
+  else
+    _server = require('https').createServer(options.https, _app);
 
-	_app.io = io(_server);
+  if (!options.disableSession)
+    _app.use(session(options)); //enable session support in express
 
-	/**
-	 * The authorization event is now a middleware in socket.io > 1.0.0
-	 *
-	 * Here, we are trying to populate socket.session object.
-	 *
-	 * Call next() if OK.
-	 * Call next(new Error()) if not.
-	 */
-	_app.io.use(function(socket, next) {
+  _app.io = io(_server);
 
-		if (socket.request.headers.cookie && !options.disableSession) {
-			var _cookies = require('cookie').parse(socket.request.headers.cookie);
-			if (_cookies[options.name]) {
+  //Init IO Router
+  var _router = new Router(_app, options);
 
-				//decode the cookie using session secret
-				var _sid = require('cookie-parser').signedCookie(_cookies[options.name], options.secret);
-				
-				options.store.get(_sid, function(err, session) {
-					if (err || !session) {
-						return setInvalidSession(socket); next();
-					}
-					
-					//Adding properties
-					session.save = function(fn) {
-						options.store.set(_sid, this, (fn || function() {}));
-					}
+  // Expose new methods :
 
-					socket.session = session;
-					next();
-				});
-
-			} else {
-				setInvalidSession(socket); next();
-			}
-		} else {
-			setInvalidSession(socket); next();
-		}
-
-	});
-
-	// Expose new methods :
-
-	/**
+  /**
 	 * Start express and socket.io applications.
 	 * @params : see http://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback
 	 */
-	_app.listen = function(arg1, arg2, arg3, arg4) {
+  _app.listen = function (arg1, arg2, arg3, arg4) {
 
-		if(arg1 === undefined) throw Error("Sockpress : Please provide at least one argument to listen function.");
+    if (arg1 === undefined) throw Error("Sockpress : Please provide at least one argument to listen function.");
 
-		if(!_app.io.hasListeners) {
-			_router.addListeners(_app.io);
-			_app.io.hasListeners = true;
-		}
+    if (!_app.io.hasListeners) {
+      _router.addListeners(_app.io);
+      _app.io.hasListeners = true;
+    }
 
-		if (arg2 === undefined) return _server.listen(arg1);
-		else if (arg3 === undefined) return _server.listen(arg1, arg2);
-		else if (arg4 === undefined) return _server.listen(arg1, arg2, arg3);
-		else return _server.listen(arg1, arg2, arg3, arg4);
-		
-	}
+    if (arg2 === undefined) return _server.listen(arg1);
+    else if (arg3 === undefined) return _server.listen(arg1, arg2);
+    else if (arg4 === undefined) return _server.listen(arg1, arg2, arg3);
+    else return _server.listen(arg1, arg2, arg3, arg4);
 
-	/**
+  }
+
+  /**
 	 * Add a new socket.io route (convenience method)
 	 * @param  {String}   [namespace] socket.io namespace. Defaults to "/".
 	 * @param  {String}   route     the route name (should be unique)
 	 * @param  {Function} fn        function(socket, data) { ... }
 	 */
-	_app.io.route = function(namespace, route, fn) {
-		_router.add(namespace, route, fn);
-	}
+  _app.io.route = function (namespace, route, fn) {
+    _router.add(namespace, route, fn);
+  }
 
-	return _app;
+  return _app;
 
 };
 
 /** PRIVATE **/
 
 function setInvalidSession(socket) {
-	socket.session = {};
-	socket.session.save = function(callback) {
-		callback = callback || function() {};
-		callback("Session if not initialized. Init it with a classic express request.");
-	}
+  socket.session = {};
+  socket.session.save = function (callback) {
+    callback = callback || function () { };
+    callback("Session if not initialized. Init it with a classic express request.");
+  }
 };

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,79 +1,118 @@
 "use strict";
 
-var Router = function() {
+var Router = function (app, options) {
 
-	var that = this;
-	var isListening = false;
+  var that = this;
+  var isListening = false;
 
-	//expose public
-	
-	this.add = add;
-	this.addListeners = addListeners;
+  //expose public
 
-	this.routes = [];
-	this.nsps = [];
+  this.add = add;
+  this.addListeners = addListeners;
 
-	/**
+  this.routes = [];
+  this.nsps = [];
+
+
+  function _sessionHook(socket, next) {
+    if (socket.request.headers.cookie && !options.disableSession) {
+      var _cookies = require('cookie').parse(socket.request.headers.cookie);
+      if (_cookies[options.name]) {
+
+        //decode the cookie using session secret
+        var _sid = require('cookie-parser').signedCookie(_cookies[options.name], options.secret);
+
+        options.store.get(_sid, function (err, session) {
+          if (err || !session) {
+            return setInvalidSession(socket); next();
+          }
+
+          //Adding properties
+          session.save = function (fn) {
+            options.store.set(_sid, this, (fn || function () { }));
+          }
+
+          socket.session = session;
+          next();
+        });
+
+      } else {
+        setInvalidSession(socket); next();
+      }
+    } else {
+      setInvalidSession(socket); next();
+    }
+
+  }
+
+  // Base session hook
+  // namespaces register their own within addListeners
+  app.io.use(_sessionHook)
+
+  /**
 	 * Register a route in current router.
 	 * @param {String}   namespace (not mandatory argument)
 	 * @param {String}   route    The socket.io route.
 	 * @param {Function} callback Will be called with socket as a parameter.
 	 */
-	function add(namespace, route, callback) {
+  function add(namespace, route, callback) {
 
-		if(isListening) throw Error("Sockpress cannot declare another route after application start.");
+    if (isListening) throw Error("Sockpress cannot declare another route after application start.");
 
-		if(!callback) {
-			callback = route;
-			route = namespace;
-			namespace = "/";
-		}
-		if(typeof namespace !== "string" || typeof route !== "string" || typeof callback !== "function")
-			throw Error("Bad arguments in sockpress/route");
+    if (!callback) {
+      callback = route;
+      route = namespace;
+      namespace = "/";
+    }
+    if (typeof namespace !== "string" || typeof route !== "string" || typeof callback !== "function")
+      throw Error("Bad arguments in sockpress/route");
 
-		this.routes.push({namespace: namespace, route: route, fn: callback});
+    this.routes.push({ namespace: namespace, route: route, fn: callback });
 
-		if(this.nsps.indexOf(namespace) < 0)
-			this.nsps.push(namespace);
-	}
+    if (this.nsps.indexOf(namespace) < 0)
+      this.nsps.push(namespace);
+  }
 
-	/**
+  /**
 	 * Add listeners to an application for each namespace.
 	 * Warning ! Should be called after each route initialization.
 	 * @param {SocketIo} io
 	 */
-	function addListeners(io) {
+  function addListeners(io) {
 
-		for(var i = 0; i < that.nsps.length; i++) {
+    for (var i = 0; i < that.nsps.length; i++) {
 
-			(function(i) {
-				io.of(that.nsps[i]).on("connection", function(s) {
-					listen(that.nsps[i], s);
-				});
-			})(i);
-			
-		}
+      (function (i) {
+        io.of(that.nsps[i]).on("connection", function (s) {
+          listen(that.nsps[i], s);
+        });
 
-		isListening = true;
-	}
+        // For each namespace you need to register the session middleware
+        io.of(that.nsps[i]).use(_sessionHook)
+      })(i);
+
+    }
+
+    isListening = true;
+  }
 
 
-	/** PRIVATE METHODS **/
+  /** PRIVATE METHODS **/
 
-	function listen(namespace, socket) {
+  function listen(namespace, socket) {
 
-		for(var i = 0; i < that.routes.length; i++) {
+    for (var i = 0; i < that.routes.length; i++) {
 
-			if(that.routes[i].namespace !== namespace) continue;
+      if (that.routes[i].namespace !== namespace) continue;
 
-			(function(i) {
-				socket.on(that.routes[i].route, function(data) {
-					that.routes[i].fn(socket, data);
-				});
-			})(i);
-		}
+      (function (i) {
+        socket.on(that.routes[i].route, function (data) {
+          that.routes[i].fn(socket, data);
+        });
+      })(i);
+    }
 
-	}
+  }
 
 }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -46,7 +46,7 @@ var Router = function (app, options) {
   }
 
   // Base session hook
-  // namespaces register their own within addListeners
+  // namespaces register their own within 'add'
   app.io.use(_sessionHook)
 
   /**
@@ -69,8 +69,14 @@ var Router = function (app, options) {
 
     this.routes.push({ namespace: namespace, route: route, fn: callback });
 
-    if (this.nsps.indexOf(namespace) < 0)
+    if (this.nsps.indexOf(namespace) < 0) {
       this.nsps.push(namespace);
+      
+      // For each namespace you need to register the session middleware
+      // This has to be done outside of addListeners as other middleware may rely on this and can be registered before addListeners is called
+      app.io.of(namespace).use(_sessionHook)
+
+    }
   }
 
   /**
@@ -79,6 +85,7 @@ var Router = function (app, options) {
 	 * @param {SocketIo} io
 	 */
   function addListeners(io) {
+    
 
     for (var i = 0; i < that.nsps.length; i++) {
 
@@ -87,8 +94,6 @@ var Router = function (app, options) {
           listen(that.nsps[i], s);
         });
 
-        // For each namespace you need to register the session middleware
-        io.of(that.nsps[i]).use(_sessionHook)
       })(i);
 
     }
@@ -113,16 +118,6 @@ var Router = function (app, options) {
     }
 
   }
-  
-  /** PRIVATE **/
-
-  function setInvalidSession(socket) {
-    socket.session = {};
-    socket.session.save = function (callback) {
-      callback = callback || function () { };
-      callback("Session if not initialized. Init it with a classic express request.");
-    }
-  };
 
 }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -113,6 +113,16 @@ var Router = function (app, options) {
     }
 
   }
+  
+  /** PRIVATE **/
+
+  function setInvalidSession(socket) {
+    socket.session = {};
+    socket.session.save = function (callback) {
+      callback = callback || function () { };
+      callback("Session if not initialized. Init it with a classic express request.");
+    }
+  };
 
 }
 


### PR DESCRIPTION
When using routes you wouldn't get the session information on the socket as middleware in socket.io seems to only relate to the route that it was added to.

The tests did not cover this scenario and that's why it has gone undetected.