### PR TITLE
session doesn't attach to socket when there are no custom events

### DIFF
--- a/lib/routing.js
+++ b/lib/routing.js
@@ -44,9 +44,21 @@ var Routing = function (app, options) {
 
     // Either a single route or a Router object
     if(callback instanceof Route.constructor) {
+      // Hook here as connection events don't recursively call the add function, only custom events
+      addSessionMiddlewareToNamespace(route);
       _addRouteObject(namespace, route, callback);
     } else {
+      addSessionMiddlewareToNamespace(namespace);
       _addSingleRoute(namespace, route, callback);
+    }
+  }
+
+  function addSessionMiddlewareToNamespace(route) {
+    if(that.nsps.indexOf(route) < 0) {
+      that.nsps.push(route);
+      // For each namespace, we need to register the session middleware
+      // This has to be done outside of addListeners as other middleware may rely on this and can be registered before addListeners is called
+      app.io.of(route).use(sessionMiddleware);
     }
   }
 
@@ -56,13 +68,6 @@ var Routing = function (app, options) {
       'route'    : route,
       'fn'       : callback
     });
-
-    if (that.nsps.indexOf(namespace) < 0) {
-      that.nsps.push(namespace);
-      // For each namespace, we need to register the session middleware
-      // This has to be done outside of addListeners as other middleware may rely on this and can be registered before addListeners is called
-      app.io.of(namespace).use(sessionMiddleware);
-    }
   }
 
   function _addRouteObject(namespace, route, routeInstance) {


### PR DESCRIPTION
Adding of the session middleware relied on the addSingleRoute being called, when only adding the default connection events the library does not call this function but instead works directly with socket.io. My change here will make sure we add it in both scenarios.