### PR TITLE
Allow app Initialization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,11 +12,16 @@ var express = require('express'),
     Routing = require('./routing'),
     Route   = require('./route');
 
-module.exports.init = function (options) {
+module.exports.init = function (app, options) {
+  if(!app && !options) {
+    options = {};
+  }
+  else if(!options) {
+    options = app;
+    app = undefined;
+  }
 
   var _app, _server;
-
-  if (!options) options = {};
 
   //Defaults values for options
   options.name = options.name || 'sockpress.id';
@@ -24,7 +29,7 @@ module.exports.init = function (options) {
   options.resave = options.resave === undefined ? true : false;
   options.saveUninitialized = options.saveUninitialized === undefined ? true : false;
 
-  _app = express(); // Load an express instance
+  _app = app || express(); // Load an express instance
   _app.express = express; // Expose raw express object for middlewares
 
   // Load http or https nodejs server


### PR DESCRIPTION
Allow for an express app to be passed in as a model for all express routing. Particularly for use with other express wrappers.